### PR TITLE
Fix broken reference to DeadLetterQueue*Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-## 1.0.0
-  - init
-
+## 1.0.2
+ - internal: renamed DeadLetterQueueWriteManager to DeadLetterQueueWriter in tests
+ 
 ## 1.0.1
   - internal: rename DeadLetterQueueManager to DeadLetterQueueReader
+
+## 1.0.0
+  - init

--- a/logstash-input-dead_letter_queue.gemspec
+++ b/logstash-input-dead_letter_queue.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-dead_letter_queue'
-  s.version         = '1.0.1'
+  s.version         = '1.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'Logstash input to read dead lettered events'
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/unit/inputs/dead_letter_queue_spec.rb
+++ b/spec/unit/inputs/dead_letter_queue_spec.rb
@@ -4,9 +4,23 @@ require "logstash/inputs/dead_letter_queue"
 require "concurrent"
 
 describe LogStash::Inputs::DeadLetterQueue do
-  subject { LogStash::Inputs::DeadLetterQueue.new(config) }
+  let(:pipeline_id) { SecureRandom.hex(8)}
+  let(:path) { Dir.tmpdir }
+  let(:directory) { File.join(path, pipeline_id)}
 
-  it "should register" do
+  subject { LogStash::Inputs::DeadLetterQueue.new({ "path" => path,
+                                                    "pipeline_id" => pipeline_id}) }
+
+  before(:each) do
+    Dir.mkdir(directory)
+  end
+
+  it 'should register' do
     expect {subject.register}.to_not raise_error
+  end
+
+
+  after(:each) do
+    FileUtils.remove_entry_secure directory
   end
 end


### PR DESCRIPTION
Change test to refer to DeadLetterQueueWriter instead of DeadLetterQueueWriteManager
Remove unnecessary (and broken) reference to DeadLetterQueueReadManager
Change variable and access to refer to ...Reader, instead of ...ReadManager

