### PR TITLE
Build: refactor tasks (runnable on windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## pending
   - Build: cleanup/review (unused) dependencies [#36](https://github.com/logstash-plugins/logstash-input-dead_letter_queue/pull/36)
+  - Build: refactor tasks (runnable on windows) [#37](https://github.com/logstash-plugins/logstash-input-dead_letter_queue/pull/37)
 
 ## 1.1.11
   - Fix: pre-flight checks before creating DLQ reader [#35](https://github.com/logstash-plugins/logstash-input-dead_letter_queue/pull/35)

--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,11 @@
 require "logstash/devutils/rake"
 
-gradlew = File.join(Dir.pwd, 'gradlew')
-
 task :default do
   sh('rake -T')
 end
 
 task :vendor => "gradle.properties" do
-  sh "#{gradlew} --no-daemon vendor"
+  sh "#{File.join(Dir.pwd, 'gradlew')} vendor"
 end
 
 file "gradle.properties" do
@@ -20,5 +18,4 @@ file "gradle.properties" do
   end
   puts "-------------------> Wrote #{gradle_properties_file}"
   puts File.read(gradle_properties_file)
-end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,18 +1,16 @@
 require "logstash/devutils/rake"
 
+gradlew = File.join(Dir.pwd, 'gradlew')
+
 task :default do
-  system('rake -T')
+  sh('rake -T')
 end
 
 task :vendor => "gradle.properties" do
-  exit(1) unless system './gradlew vendor'
+  sh "#{gradlew} --no-daemon vendor"
 end
 
 file "gradle.properties" do
-  delete_create_gradle_properties
-end
-
-def delete_create_gradle_properties
   root_dir = File.dirname(__FILE__)
   gradle_properties_file = "#{root_dir}/gradle.properties"
   lsc_path = `bundle show logstash-core`
@@ -21,5 +19,6 @@ def delete_create_gradle_properties
     f.puts "logstashCoreGemPath=#{lsc_path}"
   end
   puts "-------------------> Wrote #{gradle_properties_file}"
-  puts `cat #{gradle_properties_file}`
+  puts File.read(gradle_properties_file)
+end
 end


### PR DESCRIPTION
Minor build changes here, but also tested the upstream ([devutils](https://github.com/elastic/logstash-devutils/pull/96)) updates to be able to run Java tests, output:
(once https://github.com/elastic/logstash-devutils/pull/96 and https://github.com/logstash-plugins/.ci/pull/36 are ready the plugin will start running Java tests)
```
logstash_1  | HOSTNAME=340beb9dc4bd
logstash_1  | ELASTIC_CONTAINER=true
logstash_1  | PWD=/usr/share/plugins/plugin
logstash_1  | HOME=/usr/share/logstash
logstash_1  | LANG=en_US.UTF-8
logstash_1  | ELASTIC_STACK_VERSION=
logstash_1  | DISTRIBUTION=default
logstash_1  | TERM=xterm
logstash_1  | LOGSTASH_SOURCE=1
logstash_1  | INTEGRATION=
logstash_1  | LS_JAVA_OPTS=-Dls.cgroup.cpuacct.path.override=/ -Dls.cgroup.cpu.path.override=/ 
logstash_1  | SHLVL=1
logstash_1  | JRUBY_OPTS=-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0 -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1
logstash_1  | LC_ALL=en_US.UTF-8
logstash_1  | SPEC_OPTS="-fd"
logstash_1  | PATH=/usr/share/logstash/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/share/logstash/vendor/jruby/bin:/usr/share/logstash/jdk/bin
logstash_1  | _=/usr/bin/env
logstash_1  | + jruby -rbundler/setup -S rake test
logstash_1  | -XX:InitialHeapSize=519638912 -XX:MaxHeapSize=8314222592 -XX:+PrintCommandLineFlags -XX:ReservedCodeCacheSize=251658240 -XX:+SegmentedCodeCache -XX:ThreadStackSize=2048 -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseParallelGC 
logstash_1  | jruby 9.2.20.1 (2.5.8) 2021-11-30 2a2962fbd1 OpenJDK 64-Bit Server VM 11.0.13+8 on 11.0.13+8 +indy +jit [linux-x86_64]
logstash_1  | /usr/share/plugins/plugin/gradlew --no-daemon vendor
logstash_1  | To honour the JVM settings for this build a new JVM will be forked. Please consider using the daemon: https://docs.gradle.org/5.6.4/userguide/gradle_daemon.html.
logstash_1  | Daemon will be stopped at the end of the build stopping after processing
logstash_1  | 
logstash_1  | BUILD SUCCESSFUL in 3s
logstash_1  | 4 actionable tasks: 2 executed, 2 up-to-date
              /usr/share/plugins/plugin/gradlew --no-daemon test
logstash_1  | To honour the JVM settings for this build a new JVM will be forked. Please consider using the daemon: https://docs.gradle.org/5.6.4/userguide/gradle_daemon.html.
logstash_1  | Daemon will be stopped at the end of the build stopping after processing
logstash_1  | 
logstash_1  | BUILD SUCCESSFUL in 27s
logstash_1  | 3 actionable tasks: 2 executed, 1 up-to-date
              /usr/share/logstash/vendor/jruby/bin/jruby -I/usr/share/logstash/vendor/jruby/lib/ruby/gems/shared/gems/rspec-core-3.11.0/lib:/usr/share/logstash/vendor/jruby/lib/ruby/gems/shared/gems/rspec-support-3.11.0/lib /usr/share/logstash/vendor/jruby/lib/ruby/gems/shared/gems/rspec-core-3.11.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
logstash_1  | -XX:InitialHeapSize=519638912 -XX:MaxHeapSize=8314222592 -XX:+PrintCommandLineFlags -XX:ReservedCodeCacheSize=251658240 -XX:+SegmentedCodeCache -XX:ThreadStackSize=2048 -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseParallelGC 
logstash_1  | jruby 9.2.20.1 (2.5.8) 2021-11-30 2a2962fbd1 OpenJDK 64-Bit Server VM 11.0.13+8 on 11.0.13+8 +indy +jit [linux-x86_64]
logstash_1  | Sending Logstash logs to null which is now configured via log4j2.properties
logstash_1  | Run options: exclude {:integration=>true, :redis=>true, :socket=>true, :performance=>true, :couchdb=>true, :elasticsearch=>true, :elasticsearch_secure=>true, :export_cypher=>true, :windows=>true}
logstash_1  | 
logstash_1  | Randomized with seed 43511
logstash_1  | 
logstash_1  | LogStash::Inputs::DeadLetterQueue
logstash_1  |   should register
logstash_1  |   test with real DLQ file
logstash_1  |     reserve original metadata
logstash_1  | 
logstash_1  | Finished in 0.96173 seconds (files took 4.76 seconds to load)
logstash_1  | 2 examples, 0 failures
logstash_1  | 
logstash_1  | Randomized with seed 43511
logstash_1  | 
ci_logstash_1 exited with code 0
Aborting on container exit...

```