### PR TITLE
Fix test dependencies to run Java tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,5 +77,6 @@ dependencies {
 
   testCompile group: 'junit', name: 'junit', version: '4.12'
   testImplementation "org.apache.logging.log4j:log4j-core:${log4jVersion}"
+  testImplementation group: 'org.jruby', name: 'jruby-complete', version: "9.2.11.0"
   testCompile fileTree(dir: logstashCoreGemPath, include: '**/*.jar')
 }

--- a/src/test/java/org/logstash/input/DeadLetterQueueInputPluginTests.java
+++ b/src/test/java/org/logstash/input/DeadLetterQueueInputPluginTests.java
@@ -32,7 +32,6 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.*;


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip] 

## What does this PR do?

Explicitly include `jruby`'s jar in test configuration. Without this the Joda time classes (shadowed in jruby's jar) and other are not accessible when instantiating Logstash's `Timestamp` class in test cases.

## Why is it important/What is the impact to the user?

Without this `./gradlew test` fails with:
```
$ ./gradlew test

> Task :compileTestJava FAILED
/home/andrea/workspace/logstash_plugins/logstash-input-dead_letter_queue/src/test/java/org/logstash/input/DeadLetterQueueInputPluginTests.java:111: error: cannot access DateTime
            DLQEntry entry = new DLQEntry(new Event(), "test", "test", "test", new Timestamp(epoch));
                                                                               ^
  class file for org.joda.time.DateTime not found
1 error

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileTestJava'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 5s
2 actionable tasks: 1 executed, 1 up-to-date
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run Java tests

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- ```
export LOGSTASH_PATH=/ls/path && export LOGSTASH_SOURCE=1
```
- `./gradlew installDefaultGems` on LS repo
- on plugin repo `./gradlew test`


