### PR TITLE
Publish cleaned metrics counter after DLQ retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.0.0
   - Introduce the boolean `clean_consumed` setting to enable the automatic removal of completely consumed segments. Requires Logstash 8.4.0 or above [#43](https://github.com/logstash-plugins/logstash-input-dead_letter_queue/pull/43)
+  - Exposes metrics about segments and events cleaned by this plugin [#45](https://github.com/logstash-plugins/logstash-input-dead_letter_queue/pull/45)
 
 ## 1.1.12
   - Fix: Replace use of block with lambda to fix wrong number of arguments error on jruby-9.3.4.0 [#42](https://github.com/logstash-plugins/logstash-input-dead_letter_queue/pull/42)

--- a/lib/logstash/inputs/dead_letter_queue.rb
+++ b/lib/logstash/inputs/dead_letter_queue.rb
@@ -66,7 +66,11 @@ class LogStash::Inputs::DeadLetterQueue < LogStash::Inputs::Base
       # clean_consumed requires the commit of offset
       raise LogStash::ConfigurationError.new("enabling clean_consumed requires commit_offsets to also be enabled")
     end
-    @inner_plugin = org.logstash.input.DeadLetterQueueInputPlugin.new(dlq_path, @commit_offsets, sincedb_path, start_timestamp, clean_consumed)
+    @inner_plugin = org.logstash.input.DeadLetterQueueInputPlugin.new(dlq_path, @commit_offsets, sincedb_path, start_timestamp, clean_consumed,
+            lambda do |segments, events|
+                metric.gauge(:consumed_segments, segments)
+                metric.gauge(:consumed_events, events)
+            end)
     @inner_plugin.register
 
     if Gem::Requirement.new('< 7.0').satisfied_by?(logstash_version)

--- a/lib/logstash/inputs/dead_letter_queue.rb
+++ b/lib/logstash/inputs/dead_letter_queue.rb
@@ -69,6 +69,8 @@ class LogStash::Inputs::DeadLetterQueue < LogStash::Inputs::Base
     @cleaned_metrics = metric.namespace(@pipeline_id)
     @inner_plugin = org.logstash.input.DeadLetterQueueInputPlugin.new(dlq_path, @commit_offsets, sincedb_path, start_timestamp, clean_consumed,
             lambda do |segments, events|
+                # gauges is used instead of metric type because the updates that comes from the
+                # DLQ reader are already absolute values and not deltas.
                 @cleaned_metrics.gauge(:cleaned_segments, segments)
                 @cleaned_metrics.gauge(:cleaned_events, events)
             end)

--- a/lib/logstash/inputs/dead_letter_queue.rb
+++ b/lib/logstash/inputs/dead_letter_queue.rb
@@ -66,10 +66,11 @@ class LogStash::Inputs::DeadLetterQueue < LogStash::Inputs::Base
       # clean_consumed requires the commit of offset
       raise LogStash::ConfigurationError.new("enabling clean_consumed requires commit_offsets to also be enabled")
     end
+    @consumed_metrics = metric.namespace(@pipeline_id)
     @inner_plugin = org.logstash.input.DeadLetterQueueInputPlugin.new(dlq_path, @commit_offsets, sincedb_path, start_timestamp, clean_consumed,
             lambda do |segments, events|
-                metric.gauge(:consumed_segments, segments)
-                metric.gauge(:consumed_events, events)
+                @consumed_metrics.gauge(:consumed_segments, segments)
+                @consumed_metrics.gauge(:consumed_events, events)
             end)
     @inner_plugin.register
 

--- a/lib/logstash/inputs/dead_letter_queue.rb
+++ b/lib/logstash/inputs/dead_letter_queue.rb
@@ -66,11 +66,11 @@ class LogStash::Inputs::DeadLetterQueue < LogStash::Inputs::Base
       # clean_consumed requires the commit of offset
       raise LogStash::ConfigurationError.new("enabling clean_consumed requires commit_offsets to also be enabled")
     end
-    @consumed_metrics = metric.namespace(@pipeline_id)
+    @cleaned_metrics = metric.namespace(@pipeline_id)
     @inner_plugin = org.logstash.input.DeadLetterQueueInputPlugin.new(dlq_path, @commit_offsets, sincedb_path, start_timestamp, clean_consumed,
             lambda do |segments, events|
-                @consumed_metrics.gauge(:consumed_segments, segments)
-                @consumed_metrics.gauge(:consumed_events, events)
+                @cleaned_metrics.gauge(:cleaned_segments, segments)
+                @cleaned_metrics.gauge(:cleaned_events, events)
             end)
     @inner_plugin.register
 

--- a/src/test/java/org/logstash/input/DeadLetterQueueInputPluginTests.java
+++ b/src/test/java/org/logstash/input/DeadLetterQueueInputPluginTests.java
@@ -39,6 +39,12 @@ import static org.junit.Assert.*;
 public class DeadLetterQueueInputPluginTests {
 
     private Path dir;
+    private final DeadLetterQueueInputPlugin.UpdateConsumedMetrics metricsSink = new DeadLetterQueueInputPlugin.UpdateConsumedMetrics() {
+        @Override
+        public void segmentsDeleted(int segments, long events) {
+
+        }
+    };
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -58,7 +64,7 @@ public class DeadLetterQueueInputPluginTests {
         }
 
         Path since = temporaryFolder.newFile(".sincedb").toPath();
-        DeadLetterQueueInputPlugin plugin = new DeadLetterQueueInputPlugin(dir, true, since, null, false);
+        DeadLetterQueueInputPlugin plugin = new DeadLetterQueueInputPlugin(dir, true, since, null, false, metricsSink);
 
         final AtomicInteger count = new AtomicInteger();
         Thread pluginThread = new Thread(() -> {
@@ -85,7 +91,7 @@ public class DeadLetterQueueInputPluginTests {
         writeEntry(queueWriter, entry);
         writeEntry(queueWriter, entry);
 
-        DeadLetterQueueInputPlugin secondPlugin = new DeadLetterQueueInputPlugin(dir, true, since, null, false);
+        DeadLetterQueueInputPlugin secondPlugin = new DeadLetterQueueInputPlugin(dir, true, since, null, false, metricsSink);
 
         pluginThread = new Thread(() -> {
             try {
@@ -119,7 +125,7 @@ public class DeadLetterQueueInputPluginTests {
             }
         }
         Path since = temporaryFolder.newFile(".sincedb").toPath();
-        DeadLetterQueueInputPlugin plugin = new DeadLetterQueueInputPlugin(dir, false, since, new Timestamp(targetDateString), false);
+        DeadLetterQueueInputPlugin plugin = new DeadLetterQueueInputPlugin(dir, false, since, new Timestamp(targetDateString), false, metricsSink);
         plugin.register();
     }
 
@@ -127,7 +133,7 @@ public class DeadLetterQueueInputPluginTests {
     public void testClosingEmptyDlq() throws Exception {
         // Plugin does nothing and does not crash
         Path since = temporaryFolder.newFile(".sincedb").toPath();
-        DeadLetterQueueInputPlugin plugin = new DeadLetterQueueInputPlugin(dir, true, since, null, false);
+        DeadLetterQueueInputPlugin plugin = new DeadLetterQueueInputPlugin(dir, true, since, null, false, metricsSink);
 
         plugin.register();
         plugin.close();
@@ -141,7 +147,7 @@ public class DeadLetterQueueInputPluginTests {
         int times = 0;
         while (times++ < 1000) {
             try {
-                DeadLetterQueueInputPlugin plugin = new DeadLetterQueueInputPlugin(queuePath, true, since, null, false);
+                DeadLetterQueueInputPlugin plugin = new DeadLetterQueueInputPlugin(queuePath, true, since, null, false, metricsSink);
                 plugin.register();
                 plugin.run((entry) -> { assertNotNull(entry); });
             } catch (NoSuchFileException e) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Exposes cleaned events and segments counter metrics


## What does this PR do?

Leverage Logstash core PR https://github.com/elastic/logstash/pull/14336 to get notified of clean consumed metrics updates and publish under the plugin's subtree.
It adds the subdocument as:
```json
"<DLQ name>": {
  "cleaned_events": 43995,
  "cleaned_segments": 21
}
```
nesting it in the plugin's report.

## Why is it important/What is the impact to the user?

Enable the user to understand how the DLQ consumer pipeline behaves.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run as described in https://github.com/elastic/logstash/pull/14336, installing this plugin and verify it exposes the metrics as expected.

## How to test this PR locally

Run as described in https://github.com/elastic/logstash/pull/14336, installing this plugin and verify it exposes the metrics as expected

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates https://github.com/elastic/logstash/pull/14336 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->


