### PR TITLE
Retrieve logstash-core gem's path using inline bundler

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,9 @@ end
 file "gradle.properties" do
   root_dir = File.dirname(__FILE__)
   gradle_properties_file = "#{root_dir}/gradle.properties"
-  lsc_path = `bundle show logstash-core`
+  # Use same JRuby that launched this Rake
+  current_ruby_path = RbConfig::CONFIG['prefix']
+  lsc_path = `#{current_ruby_path}/bin/jruby -S bundle show logstash-core`
   FileUtils.rm_f(gradle_properties_file)
   File.open(gradle_properties_file, "w") do |f|
     f.puts "logstashCoreGemPath=#{lsc_path}"

--- a/Rakefile
+++ b/Rakefile
@@ -7,9 +7,8 @@ end
 file "gradle.properties" do
   root_dir = File.dirname(__FILE__)
   gradle_properties_file = "#{root_dir}/gradle.properties"
-  # Use same JRuby that launched this Rake
-  current_ruby_path = RbConfig::CONFIG['prefix']
-  lsc_path = `#{current_ruby_path}/bin/jruby -S bundle show logstash-core`
+  # find the path to the logstash-core gem
+  lsc_path = Bundler.rubygems.find_name("logstash-core").first.full_gem_path
   FileUtils.rm_f(gradle_properties_file)
   File.open(gradle_properties_file, "w") do |f|
     f.puts "logstashCoreGemPath=#{lsc_path}"


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?

Avoid to fork a bundler process to extract `logstash-core`'s path and use the same bundler that wraps the execution of the Rakefile itself.

## Why is it important/What is the impact to the user?

All the Rake tasks must run with same JRuby distribution that launched the execution. Without this, it uses the system's Ruby.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [x] run with system's JRuby
- [x] run with not the system's JRuby

## How to test this PR locally

Verify that it works with Logstash JRuby distribution:
```sh
export LOGSTASH_PATH=/tmp/logstash/ && export LOGSTASH_SOURCE=1
/tmp/logstash/bin/ruby -S bundle install
/tmp/logstash/bin/ruby -S exec rake vendor
```

## Related issues

- Closes #50